### PR TITLE
check if on account page

### DIFF
--- a/pmpro-lock-membership-level.php
+++ b/pmpro-lock-membership-level.php
@@ -175,7 +175,7 @@ function pmprolml_template_redirect() {
 	$user_lock_options = pmprolml_getUserOptions($current_user->ID);
 		
 	//Redirect away from the membership locked page if user isn't locked.
-	if( is_user_logged_in() && is_page($pmpro_pages['membership_locked']) && (empty($user_lock_options) || empty($user_lock_options['locked']))) {
+	if( is_user_logged_in() && ! is_page($pmpro_pages['account']) && is_page($pmpro_pages['membership_locked']) && (empty($user_lock_options) || empty($user_lock_options['locked']))) {
 		if(pmpro_hasMembershipLevel()) {
 			wp_redirect(pmpro_url('account'));
 			exit;


### PR DESCRIPTION
`function pmprolml_template_redirect()`: When no locked page is defined in settings `is_page($pmpro_pages['membership_locked'])` returns true on the account page creating an indefinite loop

https://github.com/strangerstudios/pmpro-lock-membership-level/blob/346df669144fd789b6eb4b08e0e4cbb9e255147c/pmpro-lock-membership-level.php#L178