### PR TITLE
Now redirecting to account page if lock page not set

### DIFF
--- a/pmpro-lock-membership-level.php
+++ b/pmpro-lock-membership-level.php
@@ -470,7 +470,8 @@ function pmprolml_show_account_page_error( $content ) {
 	global $pmpro_pages;
 
 	// Check that we are on the PMPro Account page.
-	if ( empty( $pmpro_pages ) || ! is_page( $pmpro_pages['account'] ) ) {
+	if ( empty( $pmpro_pages ) || empty( $pmpro_pages['account'] ) || ! is_page( $pmpro_pages['account'] ) ) {
+
 		return $content;
 	}
 


### PR DESCRIPTION
- Users with locked memberships are now redirected to their membership account page if the lock page is not set
- Error message is being shown on membership account page if the user was redirected there to show that they have a locked membership
- Removed level-editing links from membership account page

Resolves #14 