### PR TITLE
Update headings hierarchy for a11y

### DIFF
--- a/pmpro-lock-membership-level.php
+++ b/pmpro-lock-membership-level.php
@@ -82,7 +82,7 @@ function pmprolml_show_extra_profile_fields($user) {
 	else
 		$selected_expires_year = (int)$current_year + 1;
 	?>
-	<h3><?php _e('Lock Membership', 'pmpro');?></h3>
+	<h2><?php _e('Lock Membership', 'pmpro');?></h2>
 	<table class="form-table">
 		<tr>
 			<th scope="row"><?php _e('Lock Membership Level', 'pmpro');?></th>			
@@ -321,7 +321,7 @@ function pmprolml_pmpro_membership_level_after_other_settings()
 	$level_id = intval($_REQUEST['edit']);
 	$options = pmprolml_getLevelOptions($level_id);
 ?>
-<h3 class="topborder"><?php _e('Lock Membership Level Settings', 'pmprolml');?></h3>
+<h2 class="topborder"><?php _e('Lock Membership Level Settings', 'pmprolml');?></h2>
 <p><?php _e('Use these settings to keep members from cancelling or changing levels after getting this level.', 'pmprolml');?></p>
 <table>
 <tbody class="form-table">


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.