### PR TITLE
Fixes a PHP error on Profile Save

### DIFF
--- a/pmpro-lock-membership-level.php
+++ b/pmpro-lock-membership-level.php
@@ -157,7 +157,13 @@ function pmprolml_save_extra_profile_fields( $user_id ) {
 	else
 		$lml_expiration = '';
  
-	update_user_meta( $user_id, 'pmprolml', $_POST['pmprolml'] );
+	if( ! empty( $_REQUEST['pmprolml'] ) ) {
+		$lml_set = sanitize_text_field( $_POST['pmprolml'] );
+	} else {
+		$lml_set = '';
+	}
+
+	update_user_meta( $user_id, 'pmprolml', $lml_set );
 	update_user_meta( $user_id, 'pmprolml_expiration', $lml_expiration);
 }
 add_action( 'personal_options_update', 'pmprolml_save_extra_profile_fields' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-lock-membership-level/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-lock-membership-level/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an error on profile save:

```
PHP Warning: Undefined array key “pmprolml” in /public_html/wp-content/plugins/pmpro-lock-membership-level/pmpro-lock-membership-level.php on line 172
```

### How to test the changes in this Pull Request:

1. Edit a user profile and check the checkbox to 'Lock Membership Level'. Save. 
2. Then uncheck it and save again
3. No undefined errors should show

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

