### PR TITLE
Fixing Unlock Protocol conflict

### DIFF
--- a/includes/memberslist.php
+++ b/includes/memberslist.php
@@ -137,7 +137,7 @@ add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'pmprolml_add_act
  */
 function pmprolml_member_edit_panels( $panels ) {
 	// If the class doesn't exist and the abstract class does, require the class.
-	if ( ! class_exists( 'PMProup_Member_Edit_Panel' ) && class_exists( 'PMPro_Member_Edit_Panel' ) ) {
+	if ( ! class_exists( 'PMProlml_Member_Edit_Panel' ) && class_exists( 'PMPro_Member_Edit_Panel' ) ) {
 		require_once( dirname( __FILE__ ) . '/../classes/pmprolml-class-member-edit-panel.php' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-lock-membership-level/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-lock-membership-level/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing conflict with the Unlock Protocol Add On where the R4C Edit Member panel may not show.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
