### PR TITLE
Fixing undefined function and UI issue on "never expires" locks

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -28,7 +28,7 @@ function pmprolml_show_extra_profile_fields($user) {
 		}
 	}
 
-	$lml_expiration = empty( $all_lock ) ? '' : date_i18n( 'Y-m-d 12:00:00', $all_lock['expiration'] );
+	$lml_expiration = ( empty( $all_lock ) || empty( $all_lock['expiration'] ) ) ? '' : date_i18n( 'Y-m-d 12:00:00', $all_lock['expiration'] );
 		
 	//some vars for the dates
 	$current_day = date("j", current_time('timestamp'));			
@@ -127,7 +127,7 @@ function pmprolml_save_extra_profile_fields( $user_id ) {
 
 	if ( empty( sanitize_text_field( $_POST['pmprolml'] ) ) ) {
 		// Delete the "all" lock for the user.
-		pmprolml_delete_lock( $user_id, 0 );
+		pmprolml_delete_lock_for_user( $user_id, 0 );
 	} else {
 		// Update the "all" lock for the user.
 		$expiration = empty( $_POST['lml_expiration'] ) ? 0 : strtotime( $_POST['lml_expiration_year'] . '-' . $_POST['lml_expiration_month'] . '-' . $_POST['lml_expiration_day'] . ' 12:00:00' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-lock-membership-level/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-lock-membership-level/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- No longer using undefined function `pmprolml_delete_lock()`
- Fixed issue where, when using PMPro v2.x, editing a user with a "never expires" lock would show the lock as "expires Jan 1 1970".

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
