### PR TITLE
ENHANCEMENT: Add hint text for Membership Level field

### DIFF
--- a/classes/pmprolml-class-member-edit-panel.php
+++ b/classes/pmprolml-class-member-edit-panel.php
@@ -95,7 +95,7 @@ class PMProlml_Member_Edit_Panel extends PMPro_Member_Edit_Panel {
 							</div>
 							<div class="pmpro-level_change-action">
 								<span class="pmpro-level_change-action-label">
-									<?php esc_html_e( 'Membership Level', 'pmpro-lock-membership-level' ); ?>
+									<label for="pmprolml_level_id"><?php esc_html_e( 'Membership Level', 'pmpro-lock-membership-level' ); ?></label>
 								</span>
 								<span class="pmpro-level_change-action-field">
 									<select id="pmprolml_level_id" name="pmprolml_level_id">
@@ -109,6 +109,7 @@ class PMProlml_Member_Edit_Panel extends PMPro_Member_Edit_Panel {
 										}
 										?>
 									</select>
+									<p class="description"><?php esc_html_e( 'Select "All Levels" to prevent any membership changes for this user, or select a specific level to lock only that membership.', 'pmpro-lock-membership-level' ); ?></p>
 								</span>
 							</div>
 							<div class="pmpro-level_change-action">


### PR DESCRIPTION
## Summary

Added a helpful description below the **Membership Level** dropdown on the Locked Memberships panel of the edit member screen. This clarifies how the setting works for admins managing locked memberships.

## Changes

- Added a `<label for>` wrapper around "Membership Level" text for improved accessibility
- Added a description paragraph below the select dropdown explaining:
  - "All Levels" prevents any membership changes for the user
  - Selecting a specific level locks only that membership

## Testing

1. Edit a member in the WordPress admin
2. Navigate to the "Locked Memberships" panel
3. Click "Add/Update Lock"
4. The "Membership Level" field now shows a hint explaining the options

## Screenshots

N/A - text-only change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)